### PR TITLE
ci: restore actions/upload-release-asset and actions/create-release

### DIFF
--- a/.github/workflows/ondemand.yml
+++ b/.github/workflows/ondemand.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   release:
-    uses: kagekirin/csproj-version/.github/workflows/publish.yml@main
+    uses: kagekirin/csproj-dependency-version/.github/workflows/publish.yml@main
     with:
       tag: ${{ github.event.inputs.tag }}
     secrets:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -40,24 +40,16 @@ jobs:
           tar tvf ${{ steps.pack.outputs.package }}
 
       - name: Create release
-        uses: actions/github-script@v6
+        uses: actions/create-release@v1
         id: create_release
-        #env:
-        #  GITHUB_TOKEN: ${{ github.TOKEN }}
         with:
-        #  github-token: ${{secrets.GITHUB_TOKEN}}
-          script: |
-            const release = github.rest.repos.createRelease({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              tag_name: ${{ inputs.tag }},
-              release_name: "Release ${{ inputs.tag }}",
-              prerelease: false,
-              draft: false,
-              body: '@CHANGELOG.md',
-            });
-            console.log(release);
-            return release;
+          draft: false
+          prerelease: false
+          release_name: Release ${{ inputs.tag }}
+          tag_name: ${{ inputs.tag }}
+          body_path: CHANGELOG.md
+        env:
+          GITHUB_TOKEN: ${{ github.TOKEN }}
 
       - name: Upload release artifacts
         uses: actions/upload-release-asset@v1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -59,20 +59,15 @@ jobs:
             console.log(release);
             return release;
 
-      ##- name: Upload release artifacts
-      ##  uses: actions/github-script@v6
-      ##  env:
-      ##    GITHUB_TOKEN: ${{ github.TOKEN }}
-      ##  with:
-      ##    github-token: ${{secrets.GITHUB_TOKEN}}
-      ##    script: |
-      ##      const asset = github.rest.repos.uploadReleaseAsset({
-      ##        owner: context.repo.owner,
-      ##        repo: context.repo.repo,
-      ##        release_id: context.steps.create_release.outputs.id,
-      ##        name: context.steps.pack.outputs.package,
-      ##        data: context.steps.pack.outputs.package,
-      ##      });
+      - name: Upload release artifacts
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ github.TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ${{ steps.pack.outputs.package }}
+          asset_name: ${{ steps.pack.outputs.package }}
+          asset_content_type: application/gzip
 
 
 ##  publish-to-github-registry:

--- a/.github/workflows/tagonmergepr.yml
+++ b/.github/workflows/tagonmergepr.yml
@@ -64,7 +64,7 @@ jobs:
 
   release:
     needs: bump
-    uses: kagekirin/csproj-version/.github/workflows/publish.yml@main
+    uses: kagekirin/csproj-dependency-version/.github/workflows/publish.yml@main
     with:
       tag: ${{ needs.bump.outputs.version }}
     secrets:


### PR DESCRIPTION
This reverts:
* ed51d5e refactor[ci]: replace actions/upload-release-asset with actions/github-script
* 8ac9b65 refactor[ci]: replace actions/create-release with actions/github-script

This also fixes the wrong repo being referred to for the `publish.yml`.