### PR TITLE
refactor[ci]: replace release actions with github-script actions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -40,16 +40,24 @@ jobs:
           tar tvf ${{ steps.pack.outputs.package }}
 
       - name: Create release
-        uses: actions/create-release@v1
+        uses: actions/github-script@v6
         id: create_release
+        #env:
+        #  GITHUB_TOKEN: ${{ github.TOKEN }}
         with:
-          draft: false
-          prerelease: false
-          release_name: Release ${{ inputs.tag }}
-          tag_name: ${{ inputs.tag }}
-          body_path: CHANGELOG.md
-        env:
-          GITHUB_TOKEN: ${{ github.TOKEN }}
+        #  github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            const release = github.rest.repos.createRelease({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              tag_name: ${{ inputs.tag }},
+              release_name: "Release ${{ inputs.tag }}",
+              prerelease: false,
+              draft: false,
+              body: '@CHANGELOG.md',
+            });
+            console.log(release);
+            return release;
 
       - name: Upload release artifacts
         uses: actions/upload-release-asset@v1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -59,15 +59,20 @@ jobs:
             console.log(release);
             return release;
 
-      - name: Upload release artifacts
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ github.TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ${{ steps.pack.outputs.package }}
-          asset_name: ${{ steps.pack.outputs.package }}
-          asset_content_type: application/gzip
+      ##- name: Upload release artifacts
+      ##  uses: actions/github-script@v6
+      ##  env:
+      ##    GITHUB_TOKEN: ${{ github.TOKEN }}
+      ##  with:
+      ##    github-token: ${{secrets.GITHUB_TOKEN}}
+      ##    script: |
+      ##      const asset = github.rest.repos.uploadReleaseAsset({
+      ##        owner: context.repo.owner,
+      ##        repo: context.repo.repo,
+      ##        release_id: context.steps.create_release.outputs.id,
+      ##        name: context.steps.pack.outputs.package,
+      ##        data: context.steps.pack.outputs.package,
+      ##      });
 
 
 ##  publish-to-github-registry:


### PR DESCRIPTION
This reverts the revert commits:
* be750df refactor[ci]: restore actions/create-release
* 396396e refactor[ci]: restore actions/upload-release-asset