### PR TITLE
fix[ci]: pass inputs.tag as string

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -50,7 +50,7 @@ jobs:
             const release = github.rest.repos.createRelease({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              tag_name: context.inputs.tag,
+              tag_name: "${{ inputs.tag }}",
               release_name: "Release ${{ inputs.tag }}",
               prerelease: false,
               draft: false,


### PR DESCRIPTION
reason: 'context.inputs.tag' doesn't exist, it seems.